### PR TITLE
Revert the revert after fixing the override source so that it works with bash 3.x

### DIFF
--- a/bin/function_override.sh.erb
+++ b/bin/function_override.sh.erb
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+function <%=function_command_binding_for_template%> {
+  <%=function_command_path_binding_for_template%> "${@}"
+}
+
+readonly -f <%=function_command_binding_for_template%> &> /dev/null

--- a/bin/function_override_wrapper.sh.erb
+++ b/bin/function_override_wrapper.sh.erb
@@ -1,0 +1,14 @@
+/usr/bin/env bash -c '
+# load in command and function overrides
+source <(cat <%=function_override_path_binding_for_template%>)
+
+(
+  <%=execution_binding_for_template%>
+) 2> <%=wrapped_error_path_binding_for_template%>
+command_exit_code=$?
+
+# filter stderr for readonly problems
+grep -v "readonly function" <%=wrapped_error_path_binding_for_template%> >&2
+
+# return original exit code
+exit ${command_exit_code}'

--- a/lib/rspec/shell/expectations/stubbed_command.rb
+++ b/lib/rspec/shell/expectations/stubbed_command.rb
@@ -7,7 +7,9 @@ module Rspec
         attr_reader :call_log
 
         def initialize(command, dir)
-          FileUtils.cp(stub_filepath, File.join(dir, command))
+          command_path = File.join(dir, command)
+          FileUtils.cp(stub_filepath, command_path)
+
           @call_configuration = CallConfiguration.new(
               Pathname.new(dir).join("#{command}_stub.yml"),
               command

--- a/lib/rspec/shell/expectations/stubbed_env.rb
+++ b/lib/rspec/shell/expectations/stubbed_env.rb
@@ -28,21 +28,73 @@ module Rspec
         end
 
         def stub_command(command)
+          write_function_override_file_for_command command
           StubbedCommand.new command, @dir
         end
 
         def execute(command, env_vars = {})
-          Open3.capture3(env_vars, "#{env} #{command}")
+          full_command=get_wrapped_execution_with_function_overrides(<<-multiline_script
+            #{env} source #{command}
+          multiline_script
+          )
+
+          Open3.capture3(env_vars, full_command)
         end
 
         def execute_function(script, command, env_vars = {})
-          Open3.capture3(env_vars, "bash -c 'source #{script} && #{env} #{command}'")
+          full_command=get_wrapped_execution_with_function_overrides(<<-multiline_script
+            source #{script}
+            #{env} #{command}
+          multiline_script
+          )
+
+          Open3.capture3(env_vars, full_command)
+        end
+
+        def execute_inline(command_string, env_vars = {})
+          temp_command_path=Dir::Tmpname.make_tmpname("#{@dir}/inline-", nil)
+          File.write(temp_command_path, command_string)
+          execute(temp_command_path, env_vars)
         end
 
         private
 
+        def write_function_override_file_for_command(command)
+          function_command_binding_for_template = command
+          function_command_path_binding_for_template = File.join(@dir, command)
+
+          function_override_file_path = File.join(@dir, "#{command}_overrides.sh")
+          function_override_file_template = ERB.new File.new(function_override_template_path).read, nil, "%"
+          function_override_file_content = function_override_file_template.result(binding)
+
+          File.write(function_override_file_path, function_override_file_content)
+        end
+
+        def get_wrapped_execution_with_function_overrides(execution_snippet)
+          execution_binding_for_template = execution_snippet
+          function_override_path_binding_for_template="#{@dir}/*_overrides.sh"
+          wrapped_error_path_binding_for_template = "#{@dir}/errors"
+
+          function_override_wrapper_template = ERB.new File.new(function_override_wrapper_template_path).read, nil, "%"
+
+          function_override_wrapper_template.result(binding)
+        end
+
         def env
           "PATH=#{@dir}:$PATH"
+        end
+
+        def function_override_template_path
+          project_root.join('bin', 'function_override.sh.erb')
+        end
+
+        def function_override_wrapper_template_path
+          project_root.join('bin', 'function_override_wrapper.sh.erb')
+        end
+
+        def project_root
+          Pathname.new(File.dirname(File.expand_path(__FILE__)))
+              .join('..', '..', '..', '..')
         end
       end
     end

--- a/spec/classes/stubbed_command_spec.rb
+++ b/spec/classes/stubbed_command_spec.rb
@@ -12,7 +12,7 @@ describe 'StubbedCommand' do
 
   context '#called_with_args?' do
     before(:each) do
-      @subject = Rspec::Shell::Expectations::StubbedCommand.new('command', '.')
+      @subject = Rspec::Shell::Expectations::StubbedCommand.new('command', Dir.mktmpdir)
       @stubbed_call = double(Rspec::Shell::Expectations::StubbedCall)
     end
     context 'with only a series of arguments' do
@@ -33,7 +33,7 @@ describe 'StubbedCommand' do
 
   context '#with_args' do
     before(:each) do
-      @subject = Rspec::Shell::Expectations::StubbedCommand.new('command', '.')
+      @subject = Rspec::Shell::Expectations::StubbedCommand.new('command', Dir.mktmpdir)
     end
     context 'with arguments provided' do
       it 'creates a new StubbedCall with those arguments' do

--- a/spec/classes/stubbed_env_spec.rb
+++ b/spec/classes/stubbed_env_spec.rb
@@ -1,0 +1,279 @@
+require 'English'
+require 'rspec/shell/expectations'
+
+describe 'StubbedEnv' do
+  include Rspec::Shell::Expectations
+  let(:subject) { Rspec::Shell::Expectations::StubbedEnv.new }
+
+  context '#execute_inline' do
+    context 'with a stubbed function' do
+      before(:each) do
+        @overridden_function = subject.stub_command('overridden_function')
+        @overridden_command = subject.stub_command('overridden_command')
+        @overridden_function.outputs('i was overridden')
+      end
+
+      context 'and no arguments' do
+        before(:each) do
+          @stdout, @stderr, @status = subject.execute_inline(<<-multiline_script
+            #!/usr/bin/env bash
+            function overridden_function {
+              echo 'i was not overridden'
+            }
+            overridden_function
+
+            echo 'standard error output' 1>&2
+          multiline_script
+          )
+        end
+
+        it 'calls the stubbed function' do
+          expect(@overridden_function).to be_called
+        end
+
+        it 'prints the overridden output' do
+          expect(@stdout).to eql('i was overridden')
+        end
+
+        it 'prints provided stderr output to standard error' do
+          expect(@stderr).to eql("standard error output\n")
+        end
+      end
+
+      context 'and simple arguments' do
+        before(:each) do
+          @stdout, @stderr, @status = subject.execute_inline(<<-multiline_script
+          #!/usr/bin/env bash
+            function overridden_function {
+              echo 'i was not overridden'
+            }
+            overridden_function argument_one argument_two
+
+            echo 'standard error output' 1>&2
+          multiline_script
+          )
+        end
+
+        it 'calls the stubbed function' do
+          expect(@overridden_function).to be_called_with_arguments('argument_one', 'argument_two')
+        end
+
+        it 'prints the overridden output' do
+          expect(@stdout).to eql('i was overridden')
+        end
+      end
+
+      context 'and complex arguments (spaces, etc.)' do
+        before(:each) do
+          @stdout, @stderr, @status = subject.execute_inline(<<-multiline_script
+          #!/usr/bin/env bash
+            function overridden_function {
+              echo 'i was not overridden'
+            }
+            overridden_function "argument one" "argument two"
+
+            echo 'standard error output' 1>&2
+          multiline_script
+          )
+        end
+
+        it 'calls the stubbed function' do
+          expect(@overridden_function).to be_called_with_arguments('argument one', 'argument two')
+        end
+
+        it 'prints the overridden output' do
+          expect(@stdout).to eql('i was overridden')
+        end
+      end
+    end
+    context 'with a stubbed command' do
+      before(:each) do
+        @overridden_command = subject.stub_command('overridden_command')
+        @overridden_function = subject.stub_command('overridden_function')
+        @overridden_command.outputs('i was overridden')
+      end
+
+      context 'and no arguments' do
+        before(:each) do
+          @stdout, @stderr, @status = subject.execute_inline(<<-multiline_script
+            #!/usr/bin/env bash
+            overridden_command
+          multiline_script
+          )
+        end
+
+        it 'calls the stubbed command' do
+          expect(@overridden_command).to be_called
+        end
+
+        it 'prints the overridden output' do
+          expect(@stdout).to eql('i was overridden')
+        end
+      end
+
+      context 'and simple arguments' do
+        before(:each) do
+          @stdout, @stderr, @status = subject.execute_inline(<<-multiline_script
+            #!/usr/bin/env bash
+            overridden_command argument_one argument_two
+          multiline_script
+          )
+        end
+
+        it 'calls the stubbed command' do
+          expect(@overridden_command).to be_called_with_arguments('argument_one', 'argument_two')
+        end
+
+        it 'prints the overridden output' do
+          expect(@stdout).to eql('i was overridden')
+        end
+      end
+
+      context 'and complex arguments (spaces, etc.)' do
+        before(:each) do
+          @stdout, @stderr, @status = subject.execute_inline(<<-multiline_script
+            #!/usr/bin/env bash
+            overridden_command "argument one" "argument two"
+          multiline_script
+          )
+        end
+
+        it 'calls the stubbed command' do
+          expect(@overridden_command).to be_called_with_arguments('argument one', 'argument two')
+        end
+
+        it 'prints the overridden output' do
+          expect(@stdout).to eql('i was overridden')
+        end
+      end
+    end
+  end
+
+  context '#execute_function' do
+    context 'with a stubbed function' do
+      before(:each) do
+        @overridden_function = subject.stub_command('overridden_function')
+        @overridden_command = subject.stub_command('overridden_command')
+        @overridden_function.outputs('i was overridden')
+        @overridden_function.outputs('standard error output', to: :stderr)
+      end
+
+      context 'and no arguments' do
+        before(:each) do
+          @stdout, @stderr, @status = subject.execute_function(
+              './spec/scripts/function_library.sh',
+              'overridden_function'
+          )
+        end
+
+        it 'calls the stubbed function' do
+          expect(@overridden_function).to be_called
+        end
+
+        it 'prints the overridden output' do
+          expect(@stdout).to eql('i was overridden')
+        end
+
+        it 'prints provided stderr output to standard error' do
+          expect(@stderr).to eql("standard error output\n")
+        end
+      end
+
+      context 'and simple arguments' do
+        before(:each) do
+          @stdout, @stderr, @status = subject.execute_function(
+              './spec/scripts/function_library.sh',
+              'overridden_function argument_one argument_two'
+          )
+        end
+
+        it 'calls the stubbed function' do
+          expect(@overridden_function).to be_called_with_arguments('argument_one', 'argument_two')
+        end
+
+        it 'prints the overridden output' do
+          expect(@stdout).to eql('i was overridden')
+        end
+      end
+
+      context 'and complex arguments (spaces, etc.)' do
+        before(:each) do
+          @stdout, @stderr, @status = subject.execute_function(
+              './spec/scripts/function_library.sh',
+              'overridden_function "argument one" "argument two"'
+          )
+        end
+
+        it 'calls the stubbed function' do
+          expect(@overridden_function).to be_called_with_arguments('argument one', 'argument two')
+        end
+
+        it 'prints the overridden output' do
+          expect(@stdout).to eql('i was overridden')
+        end
+      end
+    end
+    context 'with a stubbed command' do
+      before(:each) do
+        @overridden_function = subject.stub_command('overridden_function')
+        @overridden_command = subject.stub_command('overridden_command')
+        @overridden_command.outputs('i was overridden')
+      end
+
+      context 'and no arguments' do
+        before(:each) do
+          @stdout, @stderr, @status = subject.execute_function(
+              './spec/scripts/function_library.sh',
+              'overridden_command_function'
+          )
+        end
+
+        it 'calls the stubbed command' do
+          expect(@overridden_command).to be_called
+        end
+
+        it 'prints the overridden output' do
+          expect(@stdout).to eql('i was overridden')
+        end
+
+        it 'prints provided stderr output to standard error' do
+          expect(@stderr).to eql("standard error output\n")
+        end
+      end
+
+      context 'and simple arguments' do
+        before(:each) do
+          @stdout, @stderr, @status = subject.execute_function(
+              './spec/scripts/function_library.sh',
+              'overridden_command_function argument_one argument_two'
+          )
+        end
+
+        it 'calls the stubbed command' do
+          expect(@overridden_command).to be_called_with_arguments('argument_one', 'argument_two')
+        end
+
+        it 'prints the overridden output' do
+          expect(@stdout).to eql('i was overridden')
+        end
+      end
+
+      context 'and complex arguments (spaces, etc.)' do
+        before(:each) do
+          @stdout, @stderr, @status = subject.execute_function(
+              './spec/scripts/function_library.sh',
+              'overridden_command_function "argument one" "argument two"'
+          )
+        end
+
+        it 'calls the stubbed command' do
+          expect(@overridden_command).to be_called_with_arguments('argument one', 'argument two')
+        end
+
+        it 'prints the overridden output' do
+          expect(@stdout).to eql('i was overridden')
+        end
+      end
+    end
+  end
+end

--- a/spec/matchers/be_called_with_arguments_spec.rb
+++ b/spec/matchers/be_called_with_arguments_spec.rb
@@ -11,7 +11,7 @@ describe 'be_called_with_arguments' do
     context 'and no chain calls' do
       before(:each) do
         @command = stubbed_env.stub_command('stubbed_command')
-        @actual_stdout, @actual_stderr, @actual_status = stubbed_env.execute(<<-multiline_script
+        @actual_stdout, @actual_stderr, @actual_status = stubbed_env.execute_inline(<<-multiline_script
           stubbed_command first_argument second_argument
         multiline_script
         )
@@ -23,7 +23,7 @@ describe 'be_called_with_arguments' do
     context 'and the at_position chain call' do
       before(:each) do
         @command = stubbed_env.stub_command('stubbed_command')
-        @actual_stdout, @actual_stderr, @actual_status = stubbed_env.execute(<<-multiline_script
+        @actual_stdout, @actual_stderr, @actual_status = stubbed_env.execute_inline(<<-multiline_script
           stubbed_command first_argument second_argument
         multiline_script
         )
@@ -39,7 +39,7 @@ describe 'be_called_with_arguments' do
         @command = stubbed_env.stub_command('stubbed_command')
         @sub_command = @command.with_args('sub_command')
 
-        @actual_stdout, @actual_stderr, @actual_status = stubbed_env.execute(<<-multiline_script
+        @actual_stdout, @actual_stderr, @actual_status = stubbed_env.execute_inline(<<-multiline_script
           stubbed_command sub_command first_argument second_argument
         multiline_script
         )
@@ -53,7 +53,7 @@ describe 'be_called_with_arguments' do
         @command = stubbed_env.stub_command('stubbed_command')
         @sub_command = @command.with_args('sub_command')
 
-        @actual_stdout, @actual_stderr, @actual_status = stubbed_env.execute(<<-multiline_script
+        @actual_stdout, @actual_stderr, @actual_status = stubbed_env.execute_inline(<<-multiline_script
           stubbed_command sub_command first_argument second_argument
         multiline_script
         )

--- a/spec/scripts/function_library.sh
+++ b/spec/scripts/function_library.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+function overridden_function {
+  echo 'i was not overridden'
+}
+
+function overridden_command_function {
+  overridden_command "${1}" "${2}"
+  echo 'standard error output' >&2
+}

--- a/spec/stub_output_spec.rb
+++ b/spec/stub_output_spec.rb
@@ -43,7 +43,7 @@ describe 'Stub command output' do
     it 'changes standard-out' do
       command1_stub.outputs('world', to: :stderr)
       o, e, _s = subject
-      expect(e).to eql 'world'
+      expect(e).to eql "world\n"
       expect(o).to be_empty
     end
   end


### PR DESCRIPTION
Reverts mdurban/rspec-shell-expectations#13
