### PR TITLE
fix non-line_too_long Rubocop warnings

### DIFF
--- a/lib/rspec/shell/expectations/call_configuration.rb
+++ b/lib/rspec/shell/expectations/call_configuration.rb
@@ -26,7 +26,7 @@ module Rspec
 
         def write
           structure = @configuration.map do |args, results|
-            call = {
+            {
               args: args
             }.merge results
           end

--- a/lib/rspec/shell/expectations/call_log.rb
+++ b/lib/rspec/shell/expectations/call_log.rb
@@ -38,7 +38,7 @@ module Rspec
 
         def called_with_no_args?
           call_log_list = load_call_log_list
-          !call_log_list.empty? && call_log_list.first["args"].nil?
+          !call_log_list.empty? && call_log_list.first['args'].nil?
         end
 
         private
@@ -51,18 +51,19 @@ module Rspec
         end
 
         def get_sub_command_arguments_from_call_log(call_log_list, sub_command_list)
-          call_log_list.map { |call_log|
+          sub_commands = call_log_list.map do |call_log|
             call_log_argument_series = call_log['args'] || []
 
             next call_log_argument_series if sub_command_list.empty?
             next call_log_argument_series if call_log_argument_series.slice!(0, sub_command_list.size) == sub_command_list
-          }.compact
+          end
+          sub_commands.compact
         end
 
         def get_position_range_from_argument_list(argument_list, range_start_position, range_length)
-          argument_list.map { |argument_series|
+          argument_list.map do |argument_series|
             range_start_position ? argument_series[range_start_position, range_length] : argument_series
-          }
+          end
         end
 
         def argument_series_contains?(actual_argument_series, expected_argument_series)
@@ -74,7 +75,7 @@ module Rspec
         def ensure_wildcards_match(actual_argument_series, expected_argument_series)
           # yes, i know. i am disappointed in myself
           num_of_args = actual_argument_series.size
-          expected_argument_series.zip((0..num_of_args), actual_argument_series) do |expected_arg, index, actual_arg|
+          expected_argument_series.zip((0..num_of_args), actual_argument_series) do |expected_arg, index, _actual_arg|
             if expected_arg.is_a? RSpec::Mocks::ArgumentMatchers::AnyArgMatcher
               actual_argument_series[index] = expected_arg
             end

--- a/lib/rspec/shell/expectations/matchers/called_with_no_arguments.rb
+++ b/lib/rspec/shell/expectations/matchers/called_with_no_arguments.rb
@@ -1,7 +1,5 @@
 require 'rspec/expectations'
 
 RSpec::Matchers.define :be_called_with_no_arguments do
-  match do |actual_command|
-   actual_command.called_with_no_args?
-  end
+  match(&:called_with_no_args?)
 end

--- a/lib/rspec/shell/expectations/stubbed_command.rb
+++ b/lib/rspec/shell/expectations/stubbed_command.rb
@@ -9,11 +9,11 @@ module Rspec
           FileUtils.cp(stub_filepath, command_path)
           @arguments = []
           @call_configuration = CallConfiguration.new(
-              Pathname.new(dir).join("#{command}_stub.yml"),
-              command
+            Pathname.new(dir).join("#{command}_stub.yml"),
+            command
           )
           @call_log = CallLog.new(
-              Pathname.new(dir).join("#{command}_calls.yml")
+            Pathname.new(dir).join("#{command}_calls.yml")
           )
         end
 
@@ -27,7 +27,7 @@ module Rspec
         end
 
         def called_with_no_args?
-            @call_log.called_with_no_args?
+          @call_log.called_with_no_args?
         end
 
         def called_with_args?(*args, position: false)
@@ -70,8 +70,7 @@ module Rspec
         end
 
         def project_root
-          Pathname.new(File.dirname(File.expand_path(__FILE__)))
-              .join('..', '..', '..', '..')
+          Pathname.new(File.dirname(File.expand_path(__FILE__))).join('..', '..', '..', '..')
         end
       end
     end

--- a/lib/rspec/shell/expectations/stubbed_env.rb
+++ b/lib/rspec/shell/expectations/stubbed_env.rb
@@ -33,7 +33,7 @@ module Rspec
         end
 
         def execute(command, env_vars = {})
-          full_command=get_wrapped_execution_with_function_overrides(<<-multiline_script
+          full_command = get_wrapped_execution_with_function_overrides(<<-multiline_script
             #{env} source #{command}
           multiline_script
           )
@@ -42,7 +42,7 @@ module Rspec
         end
 
         def execute_function(script, command, env_vars = {})
-          full_command=get_wrapped_execution_with_function_overrides(<<-multiline_script
+          full_command = get_wrapped_execution_with_function_overrides(<<-multiline_script
             source #{script}
             #{env} #{command}
           multiline_script
@@ -52,7 +52,7 @@ module Rspec
         end
 
         def execute_inline(command_string, env_vars = {})
-          temp_command_path=Dir::Tmpname.make_tmpname("#{@dir}/inline-", nil)
+          temp_command_path = Dir::Tmpname.make_tmpname("#{@dir}/inline-", nil)
           File.write(temp_command_path, command_string)
           execute(temp_command_path, env_vars)
         end
@@ -64,7 +64,7 @@ module Rspec
           function_command_path_binding_for_template = File.join(@dir, command)
 
           function_override_file_path = File.join(@dir, "#{command}_overrides.sh")
-          function_override_file_template = ERB.new File.new(function_override_template_path).read, nil, "%"
+          function_override_file_template = ERB.new File.new(function_override_template_path).read, nil, '%'
           function_override_file_content = function_override_file_template.result(binding)
 
           File.write(function_override_file_path, function_override_file_content)
@@ -72,10 +72,10 @@ module Rspec
 
         def get_wrapped_execution_with_function_overrides(execution_snippet)
           execution_binding_for_template = execution_snippet
-          function_override_path_binding_for_template="#{@dir}/*_overrides.sh"
+          function_override_path_binding_for_template = "#{@dir}/*_overrides.sh"
           wrapped_error_path_binding_for_template = "#{@dir}/errors"
 
-          function_override_wrapper_template = ERB.new File.new(function_override_wrapper_template_path).read, nil, "%"
+          function_override_wrapper_template = ERB.new File.new(function_override_wrapper_template_path).read, nil, '%'
 
           function_override_wrapper_template.result(binding)
         end
@@ -93,8 +93,7 @@ module Rspec
         end
 
         def project_root
-          Pathname.new(File.dirname(File.expand_path(__FILE__)))
-              .join('..', '..', '..', '..')
+          Pathname.new(File.dirname(File.expand_path(__FILE__))).join('..', '..', '..', '..')
         end
       end
     end


### PR DESCRIPTION
Do this one after the "Add unit tests for/refactor stubbed_command" PR
