### PR TITLE
add tests for blank output target

### DIFF
--- a/bin/bash_stub.sh
+++ b/bin/bash_stub.sh
@@ -71,6 +71,8 @@ function print-output {
     stderr)
       echo -en "${2}" >&2
       ;;
+    '')
+      ;;
     *)
       echo -en "${2}" > "${1}"
       ;;


### PR DESCRIPTION
This is largely so it acts the same as the ruby stub.