### PR TITLE
add tests for simple conversion of all outputs values to string

### DIFF
--- a/lib/rspec/bash/command/call_configuration.rb
+++ b/lib/rspec/bash/command/call_configuration.rb
@@ -18,7 +18,7 @@ module Rspec
         current_conf = create_or_get_conf(args)
         current_conf[:outputs] << {
           target: target,
-          content: content
+          content: content.to_s
         }
       end
 

--- a/spec/classes/command/call_configuration_spec.rb
+++ b/spec/classes/command/call_configuration_spec.rb
@@ -81,6 +81,26 @@ describe 'CallConfiguration' do
   end
   context '#add_output' do
     context 'with any setup' do
+      context 'regardless of existing or non-existing configuration' do
+        let(:expected_conf) do
+          [
+            {
+              args: %w(first_argument second_argument),
+              exitcode: 0,
+              outputs: [
+                {
+                  target: :stderr,
+                  content: '2'
+                }
+              ]
+            }
+          ]
+        end
+        it 'updates the internal configuration but converts output to a string' do
+          subject.add_output(2, :stderr, %w(first_argument second_argument))
+          expect(subject.call_configuration).to eql expected_conf
+        end
+      end
       context 'with no existing configuration' do
         let(:expected_conf) do
           [

--- a/spec/integration/stubbed_command/outputs_spec.rb
+++ b/spec/integration/stubbed_command/outputs_spec.rb
@@ -278,5 +278,19 @@ describe 'StubbedCommand' do
         end
       end
     end
+
+    describe 'any target' do
+      context 'when given a non-string output' do
+        before do
+          command.outputs(['an array'], to: :stdout)
+        end
+
+        execute_script('stubbed_command first_argument second_argument')
+
+        it 'outputs the expected output to stdout' do
+          expect(stdout).to eql '["an array"]'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
One primary user of rspec-bash expressed confusion when tests would fail when they passed a non-string as the content for `.outputs`. Ultimately, bash treats stdout, stderr and file content as a string, so it makes sense to enforce that idea. Broken behavior is that the marshaller/unmarshaller will try to keep the outputs as their type that was set.