### PR TITLE
make most internals use command

### DIFF
--- a/bin/bash_wrapper.sh.erb
+++ b/bin/bash_wrapper.sh.erb
@@ -5,8 +5,8 @@
 ) 2> <%=stderr_output_path%>
 command_exit_code=$?
 
-/usr/bin/env bash <<EOF
+command bash <<EOF
   grep -v "readonly function" <%=stderr_output_path%> >&2
 EOF
 
-exit ${command_exit_code}
+command exit ${command_exit_code}

--- a/lib/rspec/bash/stubbed_env.rb
+++ b/lib/rspec/bash/stubbed_env.rb
@@ -32,13 +32,13 @@ module Rspec
       end
 
       def execute(command, env_vars = {})
-        script_runner = "source #{command}"
+        script_runner = "command source #{command}"
         script_wrapper = wrap_script(script_runner)
         execute_script(env_vars, script_wrapper)
       end
 
       def execute_function(script, command, env_vars = {})
-        script_runner = "source #{script}\n#{command}"
+        script_runner = "command source #{script}\n#{command}"
         script_wrapper = wrap_script(script_runner)
         execute_script(env_vars, script_wrapper)
       end
@@ -62,7 +62,7 @@ module Rspec
         RUBY_STUB => RubyStubScript,
         BASH_STUB => BashStubScript
       }.freeze
-      DISALLOWED_COMMANDS = %w(/usr/bin/env bash readonly function).freeze
+      DISALLOWED_COMMANDS = %w(command function).freeze
 
       def create_tcp_server
         tcp_server = TCPServer.new('localhost', 0)

--- a/lib/rspec/bash/wrapper/stub_function.rb
+++ b/lib/rspec/bash/wrapper/stub_function.rb
@@ -11,7 +11,7 @@ module Rspec
       end
 
       def footer(name)
-        "}\nreadonly -f #{name} &> /dev/null"
+        "}\ncommand readonly -f #{name} &> /dev/null"
       end
 
       def body(name)

--- a/spec/classes/stubbed_env_spec.rb
+++ b/spec/classes/stubbed_env_spec.rb
@@ -100,7 +100,7 @@ describe 'StubbedEnv' do
       subject.stub_command('first_command')
       subject.stub_command('second_command')
     end
-    disallowed_commands = %w(/usr/bin/env bash readonly function)
+    disallowed_commands = %w(command function)
     disallowed_commands.each do |command|
       it "does not allow #{command}" do
         expect { subject.stub_command(command) }.to raise_error(
@@ -112,7 +112,7 @@ describe 'StubbedEnv' do
   context '#execute' do
     it 'wraps the file to execute and sends it to Open3' do
       allow(stub_wrapper).to receive(:wrap_script)
-        .with('source file_to_execute')
+        .with('command source file_to_execute')
         .and_return('wrapped script')
       expect(Open3).to receive(:capture3)
         .with({ 'DOG' => 'cat' }, 'wrapped script')
@@ -123,7 +123,7 @@ describe 'StubbedEnv' do
   context('#execute_function') do
     it 'wraps the file to execute and sends it to Open3' do
       allow(stub_wrapper).to receive(:wrap_script)
-        .with("source file_to_execute\nfunction_to_execute")
+        .with("command source file_to_execute\nfunction_to_execute")
         .and_return('wrapped script')
       expect(Open3).to receive(:capture3)
         .with({ 'DOG' => 'cat' }, 'wrapped script')
@@ -151,7 +151,7 @@ describe 'StubbedEnv' do
     end
     it 'wraps the file to execute and sends it to Open3' do
       allow(stub_wrapper).to receive(:wrap_script)
-        .with('source file_to_execute')
+        .with('command source file_to_execute')
         .and_return('wrapped script')
       expect(Open3).to receive(:capture3)
         .with({ 'DOG' => 'cat' }, 'wrapped script')

--- a/spec/integration/edge_cases/stub_internals_spec.rb
+++ b/spec/integration/edge_cases/stub_internals_spec.rb
@@ -1,0 +1,101 @@
+require 'spec_helper'
+include Rspec::Bash
+
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/MethodLength
+def expect_normal_operation
+  it 'should not blow up the test framework' do
+    expect(first_command).to be_called_with_arguments('hello')
+  end
+
+  it 'should return given stdout' do
+    expect(stdout).to eql 'stdout'
+  end
+
+  it 'should return given stderr' do
+    expect(stderr.chomp).to eql 'stderr'
+  end
+
+  it 'should return the given exit code' do
+    expect(exitcode).to eql 1
+  end
+
+  it 'treat calls like any other stub' do
+    expect(second_command).to be_called_with_no_arguments
+  end
+end
+# rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/AbcSize
+
+describe 'integration for overrides of key stub internals' do
+  let(:stubbed_env) { create_stubbed_env }
+  let!(:first_command) do
+    stubbed_env.stub_command('first_command')
+               .outputs('stdout', to: :stdout)
+               .outputs('stderr', to: :stderr)
+               .returns_exitstatus(1)
+  end
+
+  context 'bash' do
+    let!(:second_command) { stubbed_env.stub_command('bash') }
+
+    execute_script 'bash; first_command hello'
+
+    expect_normal_operation
+  end
+
+  context 'ruby' do
+    let!(:second_command) { stubbed_env.stub_command('ruby') }
+
+    execute_script 'ruby; first_command hello'
+
+    expect_normal_operation
+  end
+
+  context '/usr/bin/env' do
+    let!(:second_command) { stubbed_env.stub_command('/usr/bin/env') }
+
+    execute_script '/usr/bin/env; first_command hello'
+
+    expect_normal_operation
+  end
+
+  context 'source' do
+    let!(:second_command) { stubbed_env.stub_command('source') }
+
+    execute_script 'source; first_command hello'
+
+    expect_normal_operation
+  end
+
+  context 'grep' do
+    let!(:second_command) { stubbed_env.stub_command('grep') }
+
+    execute_script 'grep; first_command hello'
+
+    expect_normal_operation
+  end
+
+  context 'exit' do
+    let!(:second_command) { stubbed_env.stub_command('exit') }
+
+    execute_script 'exit; first_command hello'
+
+    expect_normal_operation
+  end
+
+  context 'readonly' do
+    let!(:second_command) { stubbed_env.stub_command('readonly') }
+
+    execute_script <<-multiline_script
+      function first_command {
+        echo 'overridden'
+      }
+
+      readonly
+      first_command hello
+    multiline_script
+
+    expect_normal_operation
+  end
+end

--- a/spec/integration/stubbed_command/outputs_spec.rb
+++ b/spec/integration/stubbed_command/outputs_spec.rb
@@ -1,18 +1,6 @@
 require 'spec_helper'
 include Rspec::Bash
 
-def execute_script(script)
-  let!(:execute_results) do
-    stdout, stderr, status = stubbed_env.execute_inline(
-      script
-    )
-    [stdout, stderr, status]
-  end
-  let(:stdout) { execute_results[0] }
-  let(:stderr) { execute_results[1] }
-  let(:exitcode) { execute_results[2].exitstatus }
-end
-
 describe 'StubbedCommand' do
   let(:stubbed_env) { create_stubbed_env }
   let!(:command) { stubbed_env.stub_command('stubbed_command') }

--- a/spec/integration/stubbed_command/returns_exitstatus_spec.rb
+++ b/spec/integration/stubbed_command/returns_exitstatus_spec.rb
@@ -1,18 +1,6 @@
 require 'spec_helper'
 include Rspec::Bash
 
-def execute_script(script)
-  let!(:execute_results) do
-    stdout, stderr, status = stubbed_env.execute_inline(
-      script
-    )
-    [stdout, stderr, status]
-  end
-  let(:stdout) { execute_results[0] }
-  let(:stderr) { execute_results[1] }
-  let(:exitcode) { execute_results[2].exitstatus }
-end
-
 describe 'StubbedCommand' do
   let(:stubbed_env) { create_stubbed_env }
   let!(:command) { stubbed_env.stub_command('stubbed_command') }

--- a/spec/integration/stubbed_env/override_spec.rb
+++ b/spec/integration/stubbed_env/override_spec.rb
@@ -1,31 +1,6 @@
 require 'spec_helper'
 include Rspec::Bash
 
-def execute_script(script)
-  let!(:execute_results) do
-    stdout, stderr, status = stubbed_env.execute_inline(
-      script
-    )
-    [stdout, stderr, status]
-  end
-  let(:stdout) { execute_results[0] }
-  let(:stderr) { execute_results[1] }
-  let(:exitcode) { execute_results[2].exitstatus }
-end
-
-def execute_function(script, function)
-  let!(:execute_results) do
-    stdout, stderr, status = stubbed_env.execute_function(
-      script,
-      function
-    )
-    [stdout, stderr, status]
-  end
-  let(:stdout) { execute_results[0] }
-  let(:stderr) { execute_results[1] }
-  let(:exitcode) { execute_results[2].exitstatus }
-end
-
 describe('StubbedEnv override tests') do
   subject { create_stubbed_env }
   let(:stubbed_env) { subject }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,3 +14,28 @@ require 'helper/shared_tmpdir'
 RSpec.configure do |c|
   c.include Rspec::Bash
 end
+
+def execute_script(script)
+  let!(:execute_results) do
+    stdout, stderr, status = stubbed_env.execute_inline(
+      script
+    )
+    [stdout, stderr, status]
+  end
+  let(:stdout) { execute_results[0] }
+  let(:stderr) { execute_results[1] }
+  let(:exitcode) { execute_results[2].exitstatus }
+end
+
+def execute_function(script, function)
+  let!(:execute_results) do
+    stdout, stderr, status = stubbed_env.execute_function(
+      script,
+      function
+    )
+    [stdout, stderr, status]
+  end
+  let(:stdout) { execute_results[0] }
+  let(:stderr) { execute_results[1] }
+  let(:exitcode) { execute_results[2].exitstatus }
+end


### PR DESCRIPTION
- Went through internals and made as many as I could use `command`
- This frees up users to be able to stub `bash`, `source`, `readonly`, etc.