### PR TITLE
add type field to outputs to help it be explicit

### DIFF
--- a/lib/rspec/bash/command/call_configuration.rb
+++ b/lib/rspec/bash/command/call_configuration.rb
@@ -16,8 +16,10 @@ module Rspec
 
       def add_output(content, target, args = [])
         current_conf = create_or_get_conf(args)
+        type = determine_output_type(target)
         current_conf[:outputs] << {
           target: target,
+          type: type,
           content: content.to_s
         }
       end
@@ -70,6 +72,11 @@ module Rspec
         current_conf = @call_configuration.select { |conf| conf[:args] == args }
         @call_configuration << new_conf if current_conf.empty?
         current_conf.first || new_conf
+      end
+
+      def determine_output_type(target)
+        is_a_file_target = !([:stdout, :stderr].include? target)
+        is_a_file_target ? :file : target
       end
     end
   end

--- a/spec/classes/command/call_configuration_spec.rb
+++ b/spec/classes/command/call_configuration_spec.rb
@@ -90,6 +90,7 @@ describe 'CallConfiguration' do
               outputs: [
                 {
                   target: :stderr,
+                  type: :stderr,
                   content: '2'
                 }
               ]
@@ -110,6 +111,7 @@ describe 'CallConfiguration' do
               outputs: [
                 {
                   target: :stderr,
+                  type: :stderr,
                   content: 'new_content'
                 }
               ]
@@ -130,6 +132,7 @@ describe 'CallConfiguration' do
               outputs: [
                 {
                   target: :stdout,
+                  type: :stdout,
                   content: 'different_content'
                 }
               ]
@@ -140,6 +143,7 @@ describe 'CallConfiguration' do
               outputs: [
                 {
                   target: :stderr,
+                  type: :stderr,
                   content: 'new_content'
                 }
               ]
@@ -154,6 +158,7 @@ describe 'CallConfiguration' do
               outputs: [
                 {
                   target: :stdout,
+                  type: :stdout,
                   content: 'different_content'
                 }
               ]
@@ -174,10 +179,12 @@ describe 'CallConfiguration' do
               outputs: [
                 {
                   target: :stdout,
+                  type: :stdout,
                   content: 'old_content'
                 },
                 {
                   target: :stderr,
+                  type: :stderr,
                   content: 'new_content'
                 }
               ]
@@ -192,6 +199,7 @@ describe 'CallConfiguration' do
               outputs: [
                 {
                   target: :stdout,
+                  type: :stdout,
                   content: 'old_content'
                 }
               ]
@@ -234,6 +242,7 @@ describe 'CallConfiguration' do
             exitcode: 2,
             outputs: [
               target: 'first_argument-something-second_argument-another.txt',
+              type: :file,
               content: 'dynamically generated file name contents'
             ]
           }
@@ -250,6 +259,7 @@ describe 'CallConfiguration' do
                   :arg2,
                   '-another.txt'
                 ],
+                type: :file,
                 content: 'dynamically generated file name contents'
               ]
             }

--- a/spec/integration/stubbed_command/outputs_spec.rb
+++ b/spec/integration/stubbed_command/outputs_spec.rb
@@ -277,6 +277,25 @@ describe 'StubbedCommand' do
           FileUtils.remove_entry_secure dynamic_file
         end
       end
+
+      describe 'when given a filename that matches the stdout target' do
+        let(:stdout_file) { Pathname.new('stdout') }
+
+        before do
+          command
+            .outputs('i am supposed to go to a file', to: 'stdout')
+        end
+
+        execute_script('stubbed_command poglet piglet')
+
+        it 'outputs the expected content to the file' do
+          expect(stdout_file.read).to eql 'i am supposed to go to a file'
+        end
+
+        after(:each) do
+          FileUtils.remove_entry_secure stdout_file
+        end
+      end
     end
 
     describe 'any target' do

--- a/spec/integration/wrapper/bash_stub_script_spec.rb
+++ b/spec/integration/wrapper/bash_stub_script_spec.rb
@@ -213,8 +213,8 @@ describe 'BashStub' do
   end
 
   context '.print-output' do
-    context 'given a stdout target and its associated content' do
-      execute_script("print-output 'stdout' '\\nstdout \\\\nstdout\nstdout\\n'")
+    context 'given a stdout type and target and its associated content' do
+      execute_script("print-output 'stdout' 'stdout' '\\nstdout \\\\nstdout\nstdout\\n'")
 
       it 'prints the output to stdout' do
         expect(stdout).to eql "\nstdout \\nstdout\nstdout\n"
@@ -225,8 +225,8 @@ describe 'BashStub' do
       end
     end
 
-    context 'given a stderr target and its associated content' do
-      execute_script("print-output 'stderr' '\\nstderr \\\\nstderr\nstderr\\n'")
+    context 'given a stderr type and target and its associated content' do
+      execute_script("print-output 'stderr' 'stderr' '\\nstderr \\\\nstderr\nstderr\\n'")
 
       it 'prints the output to stderr' do
         expect(stderr).to eql "\nstderr \\nstderr\nstderr\n"
@@ -237,8 +237,8 @@ describe 'BashStub' do
       end
     end
 
-    context 'given a file target (anything but stderr or stdout)' do
-      execute_script("print-output '<temp file>' '\\ntofile \\\\ntofile\ntofile\\n'")
+    context 'given a file type and target (anything but stderr or stdout)' do
+      execute_script("print-output 'file' '<temp file>' '\\ntofile \\\\ntofile\ntofile\\n'")
 
       it 'prints the output to the file' do
         expect(temp_file.read).to eql "\ntofile \\ntofile\ntofile\n"
@@ -252,8 +252,8 @@ describe 'BashStub' do
         expect(stdout.chomp).to eql ''
       end
     end
-    context 'given a file target that is an empty string' do
-      execute_script("print-output '' '\\ntofile \\\\ntofile\ntofile\\n'")
+    context 'given a file type and target that is an empty string' do
+      execute_script("print-output 'file' '' '\\ntofile \\\\ntofile\ntofile\\n'")
 
       it 'does not exit with a non-zero exit code' do
         expect(exit_code).to eql 0
@@ -352,6 +352,9 @@ describe 'BashStub' do
           .with_args('call conf', 'outputs\..*\.target')
           .outputs("stdout\nstderr\ntofile\n")
         @extract_string_properties
+          .with_args('call conf', 'outputs\..*\.type')
+          .outputs("stdout\nstderr\nfile\n")
+        @extract_string_properties
           .with_args('call conf', 'outputs\..*\.content')
           .outputs("\\nstd out\\n\n\\nstd err\\n\n\\nto file\\n\n")
         @extract_number_properties.with_args('call conf', 'exitcode').outputs("3\n")
@@ -390,13 +393,13 @@ describe 'BashStub' do
       end
       it 'prints the extracted outputs (with newlines still escaped)' do
         expect(@print_output).to be_called_with_arguments(
-          'stdout', '\nstd out\n'
+          'stdout', 'stdout', '\nstd out\n'
         )
         expect(@print_output).to be_called_with_arguments(
-          'stderr', '\nstd err\n'
+          'stderr', 'stderr', '\nstd err\n'
         )
         expect(@print_output).to be_called_with_arguments(
-          'tofile', '\nto file\n'
+          'file', 'tofile', '\nto file\n'
         )
       end
       it 'exits with the extracted exit code' do


### PR DESCRIPTION
The ruby version of the stub runner used to rely on :stderr and :stdout for its outputs targets, which works just fine.

However, the bash stub can't see those fields as symbols so it was initially set to just match their string values of stdout and stderr. However, this means that users can't write to files with those names. This change makes the output type more explicit by setting it to :stderr, :stdout, or :file - this new type field is used to determine where output goes so it can't get mixed up.