### PR TITLE
make outputs keyed off of their target so they do not stack

### DIFF
--- a/bin/ruby_stub.rb
+++ b/bin/ruby_stub.rb
@@ -17,16 +17,16 @@ sock.close_read
 
 exit 0 if conf_from_server.empty?
 
-(conf_from_server[:outputs] || []).each do |data|
-  if data[:target] == :stdout
+(conf_from_server[:outputs] || []).each do |target, data|
+  if target == :stdout
     $stdout.print data[:content]
     next
   end
-  if data[:target] == :stderr
+  if target == :stderr
     $stderr.print data[:content]
     next
   end
-  Pathname.new(data[:target]).open('w') do |f|
+  Pathname.new(target).open('w') do |f|
     f.print data[:content]
   end
 end

--- a/spec/classes/util/call_conf_argument_list_matcher_spec.rb
+++ b/spec/classes/util/call_conf_argument_list_matcher_spec.rb
@@ -9,134 +9,134 @@ describe 'CallConfArgumentListMatcher' do
           {
             args: [],
             exitcode: 6,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'seventh_content'
               }
-            ]
+            }
           },
           {
             args: %w(first_argument second_argument third_argument),
             exitcode: 1,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'second_content'
               }
-            ]
+            }
           },
           {
             args: ['first_argument', anything, anything],
             exitcode: 3,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'fourth_content'
               }
-            ]
+            }
           },
           {
             args: [anything, 'second_argument'],
             exitcode: 4,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'fifth_content'
               }
-            ]
+            }
           },
           {
             args: %w(first_argument second_argument),
             exitcode: 0,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'first_content'
               }
-            ]
+            }
           },
           {
             args: %w(first_argument second_argument),
             exitcode: 2,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'third_content'
               }
-            ]
+            }
           },
           {
             args: [anything, anything, anything, anything],
             exitcode: 5,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'sixth_content'
               }
-            ]
+            }
           },
           {
             args: [anything, anything, 'third_argument', anything, anything],
             exitcode: 7,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'eighth_content'
               }
-            ]
+            }
           },
           {
             args: [anything, anything, anything, anything, anything],
             exitcode: 8,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'ninth_content'
               }
-            ]
+            }
           },
           {
             args: [anything],
             exitcode: 9,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'tenth_content'
               }
-            ]
+            }
           },
           {
             args: [anything],
             exitcode: 10,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'eleventh_content'
               }
-            ]
+            }
           }
         ]
       end
 
       it 'returns the longest conf match' do
         argument_list_from_call = %w(first_argument second_argument third_argument)
-        subject = CallConfArgumentListMatcher.new(call_conf_list)
-        call_conf_match = subject.get_best_call_conf(argument_list_from_call)
+        subject                 = CallConfArgumentListMatcher.new(call_conf_list)
+        call_conf_match         = subject.get_best_call_conf(argument_list_from_call)
         expect(call_conf_match).to eql call_conf_list.at(2)
       end
 
       it 'returns the last longest conf match for multiple exact matches' do
         argument_list_from_call = %w(first_argument second_argument)
-        subject = CallConfArgumentListMatcher.new(call_conf_list)
-        call_conf_match = subject.get_best_call_conf(argument_list_from_call)
+        subject                 = CallConfArgumentListMatcher.new(call_conf_list)
+        call_conf_match         = subject.get_best_call_conf(argument_list_from_call)
         expect(call_conf_match).to eql call_conf_list.at(5)
       end
 
       it 'returns the longest conf match for any_arg v. anything matches' do
         argument_list_from_call = %w(first_argument second_argument third_argument fourth_argument)
-        subject = CallConfArgumentListMatcher.new(call_conf_list)
-        call_conf_match = subject.get_best_call_conf(argument_list_from_call)
+        subject                 = CallConfArgumentListMatcher.new(call_conf_list)
+        call_conf_match         = subject.get_best_call_conf(argument_list_from_call)
         expect(call_conf_match).to eql call_conf_list.at(6)
       end
 
@@ -145,15 +145,15 @@ describe 'CallConfArgumentListMatcher' do
           first_argument second_argument third_argument
           fourth_argument fifth_argument
         )
-        subject = CallConfArgumentListMatcher.new(call_conf_list)
-        call_conf_match = subject.get_best_call_conf(argument_list_from_call)
+        subject                 = CallConfArgumentListMatcher.new(call_conf_list)
+        call_conf_match         = subject.get_best_call_conf(argument_list_from_call)
         expect(call_conf_match).to eql call_conf_list.at(8)
       end
 
       it 'returns the last anything match for multiple, all anything matches' do
         argument_list_from_call = %w(first_argument)
-        subject = CallConfArgumentListMatcher.new(call_conf_list)
-        call_conf_match = subject.get_best_call_conf(argument_list_from_call)
+        subject                 = CallConfArgumentListMatcher.new(call_conf_list)
+        call_conf_match         = subject.get_best_call_conf(argument_list_from_call)
         expect(call_conf_match).to eql call_conf_list.at(10)
       end
     end
@@ -163,62 +163,62 @@ describe 'CallConfArgumentListMatcher' do
           {
             args: %w(first_argument second_argument),
             exitcode: 0,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'first_content'
               }
-            ]
+            }
           },
           {
             args: %w(first_argument second_argument third_argument),
             exitcode: 1,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'second_content'
               }
-            ]
+            }
           },
           {
             args: %w(first_argument second_argument),
             exitcode: 2,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'third_content'
               }
-            ]
+            }
           },
           {
             args: ['first_argument', anything, 'third_argument'],
             exitcode: 3,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'fourth_content'
               }
-            ]
+            }
           },
           {
             args: [anything, 'second_argument'],
             exitcode: 4,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'fifth_content'
               }
-            ]
+            }
           },
           {
             args: [anything, anything, anything, anything],
             exitcode: 5,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'sixth_content'
               }
-            ]
+            }
           }
         ]
       end
@@ -226,8 +226,8 @@ describe 'CallConfArgumentListMatcher' do
       it 'returns an empty conf for no matches' do
         argument_list_from_call =
           %w(first_argument second_argument third_argument fourth_argument fifth_argument)
-        subject = CallConfArgumentListMatcher.new(call_conf_list)
-        call_conf_match = subject.get_best_call_conf(argument_list_from_call)
+        subject                 = CallConfArgumentListMatcher.new(call_conf_list)
+        call_conf_match         = subject.get_best_call_conf(argument_list_from_call)
         expect(call_conf_match).to be_empty
       end
     end
@@ -239,72 +239,72 @@ describe 'CallConfArgumentListMatcher' do
           {
             args: %w(first_argument second_argument),
             exitcode: 0,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'first_content'
               }
-            ]
+            }
           },
           {
             args: %w(first_argument second_argument third_argument),
             exitcode: 1,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'second_content'
               }
-            ]
+            }
           },
           {
             args: %w(first_argument second_argument),
             exitcode: 2,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'third_content'
               }
-            ]
+            }
           },
           {
             args: ['first_argument', YAML.load(YAML.dump(anything)), 'third_argument'],
             exitcode: 3,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'fourth_content'
               }
-            ]
+            }
           },
           {
             args: [anything, 'second_argument'],
             exitcode: 4,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'fifth_content'
               }
-            ]
+            }
           },
           {
             args: [anything, anything, anything, anything],
             exitcode: 5,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'sixth_content'
               }
-            ]
+            }
           },
           {
             args: [],
             exitcode: 6,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'seventh_content'
               }
-            ]
+            }
           },
           {
             args: [
@@ -312,12 +312,12 @@ describe 'CallConfArgumentListMatcher' do
               'third_argument', 'fourth_argument', any_args
             ],
             exitcode: 6,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'seventh_content'
               }
-            ]
+            }
           },
           {
             args: [
@@ -325,34 +325,34 @@ describe 'CallConfArgumentListMatcher' do
               'third_argument', 'fourth_argument', YAML.load(YAML.dump(any_args))
             ],
             exitcode: 6,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'seventh_content'
               }
-            ]
+            }
           }
         ]
       end
 
       it 'returns the correct confs for a single exact/anything argument match' do
         argument_list_from_call = %w(first_argument second_argument third_argument)
-        subject = CallConfArgumentListMatcher.new(call_conf_list)
-        call_conf_match_list = subject.get_call_conf_matches(argument_list_from_call)
+        subject                 = CallConfArgumentListMatcher.new(call_conf_list)
+        call_conf_match_list    = subject.get_call_conf_matches(argument_list_from_call)
         expect(call_conf_match_list).to eql call_conf_list.values_at(1, 3, 6)
       end
 
       it 'returns the correct confs for multiple exact/anything argument matches' do
         argument_list_from_call = %w(first_argument second_argument)
-        subject = CallConfArgumentListMatcher.new(call_conf_list)
-        call_conf_match_list = subject.get_call_conf_matches(argument_list_from_call)
+        subject                 = CallConfArgumentListMatcher.new(call_conf_list)
+        call_conf_match_list    = subject.get_call_conf_matches(argument_list_from_call)
         expect(call_conf_match_list).to eql call_conf_list.values_at(0, 2, 4, 6)
       end
 
       it 'returns the correct confs for the all argument match' do
         argument_list_from_call = %w(first_argument)
-        subject = CallConfArgumentListMatcher.new(call_conf_list)
-        call_conf_match_list = subject.get_call_conf_matches(argument_list_from_call)
+        subject                 = CallConfArgumentListMatcher.new(call_conf_list)
+        call_conf_match_list    = subject.get_call_conf_matches(argument_list_from_call)
         expect(call_conf_match_list).to eql call_conf_list.values_at(6)
       end
 
@@ -361,8 +361,8 @@ describe 'CallConfArgumentListMatcher' do
           first_argument second_argument
           third_argument fourth_argument fifth_argument
         )
-        subject = CallConfArgumentListMatcher.new(call_conf_list)
-        actual_args_match = subject.get_call_conf_matches(argument_list_from_call)
+        subject                 = CallConfArgumentListMatcher.new(call_conf_list)
+        actual_args_match       = subject.get_call_conf_matches(argument_list_from_call)
         expect(actual_args_match).to eql call_conf_list.values_at(6, 7, 8)
       end
     end
@@ -374,94 +374,94 @@ describe 'CallConfArgumentListMatcher' do
           {
             args: %w(first_argument second_argument),
             exitcode: 0,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'first_content'
               }
-            ]
+            }
           },
           {
             args: %w(first_argument second_argument third_argument),
             exitcode: 1,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'second_content'
               }
-            ]
+            }
           },
           {
             args: %w(first_argument second_argument),
             exitcode: 2,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'third_content'
               }
-            ]
+            }
           },
           {
             args: ['first_argument', anything, 'third_argument'],
             exitcode: 3,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'fourth_content'
               }
-            ]
+            }
           },
           {
             args: [anything, 'second_argument'],
             exitcode: 4,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'fifth_content'
               }
-            ]
+            }
           },
           {
             args: [anything, anything, anything, anything],
             exitcode: 5,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'sixth_content'
               }
-            ]
+            }
           },
           {
             args: [],
             exitcode: 7,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'eighth_content'
               }
-            ]
+            }
           }
         ]
       end
 
       it 'returns the correct confs for a single exact/anything argument match' do
         argument_list_from_call = %w(first_argument second_argument third_argument)
-        subject = CallConfArgumentListMatcher.new(call_conf_list)
-        actual_args_match = subject.args_match?(argument_list_from_call)
+        subject                 = CallConfArgumentListMatcher.new(call_conf_list)
+        actual_args_match       = subject.args_match?(argument_list_from_call)
         expect(actual_args_match).to be true
       end
 
       it 'returns the correct confs for multiple exact/anything argument matches' do
         argument_list_from_call = %w(first_argument second_argument)
-        subject = CallConfArgumentListMatcher.new(call_conf_list)
-        actual_args_match = subject.args_match?(argument_list_from_call)
+        subject                 = CallConfArgumentListMatcher.new(call_conf_list)
+        actual_args_match       = subject.args_match?(argument_list_from_call)
         expect(actual_args_match).to be true
       end
 
       it 'returns the correct confs for the all argument match' do
         argument_list_from_call = %w(first_argument)
-        subject = CallConfArgumentListMatcher.new(call_conf_list)
-        actual_args_match = subject.args_match?(argument_list_from_call)
+        subject                 = CallConfArgumentListMatcher.new(call_conf_list)
+        actual_args_match       = subject.args_match?(argument_list_from_call)
         expect(actual_args_match).to be true
       end
     end
@@ -471,62 +471,62 @@ describe 'CallConfArgumentListMatcher' do
           {
             args: %w(first_argument second_argument),
             exitcode: 0,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'first_content'
               }
-            ]
+            }
           },
           {
             args: %w(first_argument second_argument third_argument),
             exitcode: 1,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'second_content'
               }
-            ]
+            }
           },
           {
             args: %w(first_argument second_argument),
             exitcode: 2,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'third_content'
               }
-            ]
+            }
           },
           {
             args: ['first_argument', anything, 'third_argument'],
             exitcode: 3,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'fourth_content'
               }
-            ]
+            }
           },
           {
             args: [anything, 'second_argument'],
             exitcode: 4,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'fifth_content'
               }
-            ]
+            }
           },
           {
             args: [anything, anything, anything, anything],
             exitcode: 5,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'sixth_content'
               }
-            ]
+            }
           },
           {
             args: [
@@ -534,34 +534,34 @@ describe 'CallConfArgumentListMatcher' do
               'third_argument', 'fourth_argument', any_args
             ],
             exitcode: 6,
-            outputs: [
-              {
+            outputs: {
+              stdout: {
                 target: :stdout,
                 content: 'seventh_content'
               }
-            ]
+            }
           }
         ]
       end
 
       it 'returns the correct confs for a single exact/anything argument match' do
         argument_list_from_call = %w(first_argument second_argument third_argument)
-        subject = CallConfArgumentListMatcher.new(call_conf_list)
-        actual_args_match = subject.args_match?(argument_list_from_call)
+        subject                 = CallConfArgumentListMatcher.new(call_conf_list)
+        actual_args_match       = subject.args_match?(argument_list_from_call)
         expect(actual_args_match).to be true
       end
 
       it 'returns the correct confs for multiple exact/anything argument matches' do
         argument_list_from_call = %w(first_argument second_argument)
-        subject = CallConfArgumentListMatcher.new(call_conf_list)
-        actual_args_match = subject.args_match?(argument_list_from_call)
+        subject                 = CallConfArgumentListMatcher.new(call_conf_list)
+        actual_args_match       = subject.args_match?(argument_list_from_call)
         expect(actual_args_match).to be true
       end
 
       it 'returns the correct confs for the all argument match' do
         argument_list_from_call = %w(first_argument)
-        subject = CallConfArgumentListMatcher.new(call_conf_list)
-        actual_args_match = subject.args_match?(argument_list_from_call)
+        subject                 = CallConfArgumentListMatcher.new(call_conf_list)
+        actual_args_match       = subject.args_match?(argument_list_from_call)
         expect(actual_args_match).to be false
       end
 
@@ -570,8 +570,8 @@ describe 'CallConfArgumentListMatcher' do
           first_argument second_argument
           third_argument fourth_argument fifth_argument
         )
-        subject = CallConfArgumentListMatcher.new(call_conf_list)
-        actual_args_match = subject.args_match?(argument_list_from_call)
+        subject                 = CallConfArgumentListMatcher.new(call_conf_list)
+        actual_args_match       = subject.args_match?(argument_list_from_call)
         expect(actual_args_match).to be true
       end
     end

--- a/spec/classes/wrapper/ruby_stub_script_spec.rb
+++ b/spec/classes/wrapper/ruby_stub_script_spec.rb
@@ -133,20 +133,20 @@ describe 'RubyStubFunction' do
     before do
       stdout_configuration = {
         args: [],
-        outputs: [
-          {
+        outputs: {
+          stderr: {
             target: :stderr,
             content: "stderr\n"
           },
-          {
+          stdout: {
             target: :stdout,
             content: "stdout\n"
           },
-          {
+          'tofile' => {
             target: 'tofile',
             content: "tofile\n"
           }
-        ],
+        },
         exitcode: 8
       }
       allow(stub_socket).to receive(:read).and_return(Marshal.dump(stdout_configuration))

--- a/spec/integration/stubbed_command/outputs_spec.rb
+++ b/spec/integration/stubbed_command/outputs_spec.rb
@@ -291,6 +291,18 @@ describe 'StubbedCommand' do
           expect(stdout).to eql '["an array"]'
         end
       end
+      context 'when given multiple outputs settings' do
+        before do
+          command.outputs('first output', to: :stdout)
+          command.outputs('second output', to: :stdout)
+        end
+
+        execute_script('stubbed_command first_argument second_argument')
+
+        it 'outputs only the results from the second call to outputs' do
+          expect(stdout).to eql 'second output'
+        end
+      end
     end
   end
 end

--- a/spec/integration/wrapper/bash_stub_script_spec.rb
+++ b/spec/integration/wrapper/bash_stub_script_spec.rb
@@ -170,24 +170,20 @@ describe 'BashStub' do
           Sparsify.sparse(
             {
               exitcode: 10_000,
-              outputs: [
-                {
-                  target: 'stdout',
+              outputs: {
+                stdout: {
+                  target: :stdout,
                   content: "stdout\nstdout,stdout"
                 },
-                {
-                  target: 'stdout',
-                  content: 1
-                },
-                {
-                  target: 'stderr',
+                stderr: {
+                  target: :stderr,
                   content: "stderr\" stderr\nstderr"
                 },
-                {
+                'tofile' => {
                   target: 'tofile',
                   content: "tofile\ntofile:\", tofile"
                 }
-              ]
+              }
             }, sparse_array: true
           ), indent: '', space: ''
         )
@@ -208,6 +204,14 @@ describe 'BashStub' do
         )
         expect(stdout.chomp).to eql "stdout\\nstdout,stdout\nstderr\\\" stderr\\nstderr" \
         "\ntofile\\ntofile:\\\", tofile"
+      end
+
+      it 'extracts a multiple value field with a dynamic key' do
+        stdout, _stderr = stubbed_env.execute_function(
+          BashStubScript.path,
+          "extract-string-properties '#{call_conf}' 'outputs\\..*\\.target'"
+        )
+        expect(stdout.chomp).to eql "stdout\nstderr\ntofile"
       end
     end
   end


### PR DESCRIPTION
This makes it so outputs contents for the same target do not stack, but just replace each other